### PR TITLE
add 27_abstract_text_type

### DIFF
--- a/sql/27_abstract_text_type.sql
+++ b/sql/27_abstract_text_type.sql
@@ -1,0 +1,32 @@
+-- Add variable content type for abstract to table and view.
+
+ALTER TABLE lter_metabase."DataSet" ADD COLUMN "AbstractType" character varying(10);
+
+-- Column cannot be null before adding NOT NULL to it. All example data (so far) is type file.
+UPDATE lter_metabase."DataSet"
+SET "AbstractType" = 'file'
+WHERE "Abstract" like 'abstract.%.docx';
+
+ALTER TABLE lter_metabase."DataSet" ALTER COLUMN "AbstractType" SET NOT NULL;
+COMMENT ON COLUMN lter_metabase."DataSet"."AbstractType" IS 'Indicates which type of content Abstract column contains (plaintext, md, file).';
+
+CONSTRAINT "CK_DataSet_AbstractType" 
+CHECK ("AbstractType"::text = ANY (ARRAY['file'::character varying::text, 'md'::character varying::text, 'plaintext'::character varying::text])),
+
+DROP VIEW mb2eml_r.vw_eml_dataset; -- because changes output columns, cannot merely REPLACE.
+CREATE OR REPLACE VIEW mb2eml_r.vw_eml_dataset AS 
+ SELECT d."DataSetID" AS datasetid, 
+    d."Revision" AS revision_number, 
+    d."Title" AS title, 
+    d."AbstractType" AS abstract_type,
+    d."Abstract" AS abstract, 
+    d."ShortName" AS shortname, 
+    d."UpdateFrequency" AS maintenanceupdatefrequency, 
+    d."MaintenanceDescription" AS maintenance_description, 
+    d."PubDate" AS pubdate
+   FROM lter_metabase."DataSet" d
+  ORDER BY d."DataSetID";
+
+  -- record this patch has been applied
+INSERT INTO pkg_mgmt.version_tracker_metabase (major_version, minor_version, patch, date_installed, comment) 
+VALUES (0,9,27,now(),'applied 27_abstract_text_type.sql');

--- a/sql/27_abstract_text_type.sql
+++ b/sql/27_abstract_text_type.sql
@@ -27,6 +27,11 @@ CREATE OR REPLACE VIEW mb2eml_r.vw_eml_dataset AS
    FROM lter_metabase."DataSet" d
   ORDER BY d."DataSetID";
 
+ALTER TABLE mb2eml_r.vw_eml_dataset OWNER TO %db_owner%;
+GRANT SELECT ON TABLE mb2eml_r.vw_eml_dataset TO read_write_user;
+GRANT SELECT ON TABLE mb2eml_r.vw_eml_dataset TO read_only_user;
+GRANT ALL ON TABLE mb2eml_r.vw_eml_dataset TO %db_owner%;
+
   -- record this patch has been applied
 INSERT INTO pkg_mgmt.version_tracker_metabase (major_version, minor_version, patch, date_installed, comment) 
 VALUES (0,9,27,now(),'applied 27_abstract_text_type.sql');


### PR DESCRIPTION
Two places in eml the complex text type is handled by metabase as a choice of plain text, markdown (only with eml2.2) or a filename of a Word doc external to metabase. (There is also a special case for content as xml, not described here.) Following the code pattern used with MethodStep's Description and DescriptionType column, I added an AbstractType column to the DataSet table (which already had the Abstract column). 

I added a column abstract_type to the corresponding view. I noticed one column in that view had an outgoing column name inconsistent with our pattern of using eml element names all lowercase, so renamed UpdateFrequency as maintenanceupdatefrequency. 

(Special note to @atn38 do you want the AbstractType column to be in order in DataSet to the left of Abstract? The ALTER will put the new column at the end but you can make magic happen with OBF, if worth the effort.)